### PR TITLE
Updated axlsx.gemspec

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path('../lib/axlsx/version', __FILE__)
+require File.expand_path('lib/axlsx/version', __dir__)
 
 Gem::Specification.new do |s|
   s.name        = 'axlsx'
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.summary     = "Excel OOXML (xlsx) with charts, styles, images and autowidth columns."
-  s.has_rdoc    = 'axlsx'
   s.license     = 'MIT'
   s.description = <<-eof
     xlsx spreadsheet generation with charts, images, automated column width, customizable styles and full schema validation. Axlsx helps you create beautiful Office Open XML Spreadsheet documents ( Excel, Google Spreadsheets, Numbers, LibreOffice) without having to understand the entire ECMA specification. Check out the README for some examples of how easy it is. Best of all, you can validate your xlsx file before serialization so you know for sure that anything generated is going to load on your client's machine.


### PR DESCRIPTION
Fixed deprecation:
```
Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```